### PR TITLE
Update to spectra

### DIFF
--- a/spectra/spec_class.py
+++ b/spectra/spec_class.py
@@ -10,8 +10,6 @@ from scipy.interpolate import interp1d, Akima1DInterpolator as Ak_i
 from .synphot import mag_calc_AB
 from .reddening import A_curve
 from .misc import *
-from astropy import convolution
-
 
 __all__ = [
   "Spectrum",

--- a/spectra/spec_functions.py
+++ b/spectra/spec_functions.py
@@ -7,8 +7,6 @@ from .spec_class import Spectrum
 from .misc import black_body
 
 __all__ = [
-  "ZeroSpectrum",
-  "UnitSpectrum",
   "Black_body",
   "join_spectra",
   "spectra_mean",

--- a/spectra/spec_functions.py
+++ b/spectra/spec_functions.py
@@ -17,7 +17,7 @@ def Black_body(x, T, wave='air', x_unit="AA", y_unit="erg/(s cm2 AA)", norm=True
   Returns a Black body curve like black_body(), but the return value
   is a Spectrum class.
   """
-  BB = ZeroSpectrum(x, f'{T}K BlackBody', wave, x_unit, "erg/(s cm2 AA)")
+  BB = Spectrum(x, 0., 0., f'{T}K BlackBody', wave, x_unit, "erg/(s cm2 AA)")
   BB.x_unit_to("AA")
   BB += black_body(BB.x, T, False)
   BB.x_unit_to(x_unit)

--- a/spectra/spec_functions.py
+++ b/spectra/spec_functions.py
@@ -14,16 +14,6 @@ __all__ = [
   "spectra_mean",
 ]
 
-def ZeroSpectrum(x, name="", wave='air', x_unit="AA", y_unit="erg/(s cm^2 AA)", head=None):
-  y = np.zeros_like(x)
-  e = np.zeros_like(x)
-  return Spectrum(x, y, e, name=name, wave=wave, x_unit=x_unit, y_unit=y_unit, head=head)
-
-def UnitSpectrum(x, name="", wave='air', x_unit="AA", head=None):
-  y = np.ones_like(x)
-  e = np.zeros_like(x)
-  return Spectrum(x, y, e, name=name, wave=wave, x_unit=x_unit, y_unit="", head=head)
-
 def Black_body(x, T, wave='air', x_unit="AA", y_unit="erg/(s cm2 AA)", norm=True):
   """
   Returns a Black body curve like black_body(), but the return value

--- a/spectra/spec_functions.py
+++ b/spectra/spec_functions.py
@@ -29,20 +29,14 @@ def Black_body(x, T, wave='air', x_unit="AA", y_unit="erg/(s cm2 AA)", norm=True
   Returns a Black body curve like black_body(), but the return value
   is a Spectrum class.
   """
-  zero_flux = np.zeros_like(x)
-  M = Spectrum(x, zero_flux, zero_flux, f'{T}K BlackBody', wave, x_unit, y_unit)
-  M.x_unit_to("AA")
-  M.y_unit_to("erg/(s cm2 AA)")
-  if wave=='air':
-    M.air_to_vac()
-  M.y = black_body(M.x, T, False)
-  if wave=='air':
-    M.vac_to_air()
-  M.x_unit_to(x_unit)
-  M.y_unit_to(y_unit)
+  BB = ZeroSpectrum(x, f'{T}K BlackBody', wave, x_unit, "erg/(s cm2 AA)")
+  BB.x_unit_to("AA")
+  BB += black_body(BB.x, T, False)
+  BB.x_unit_to(x_unit)
+  BB.y_unit_to(y_unit)
   if norm:
-    M /= M.y.max()
-  return M
+    BB /= BB.y.max()
+  return BB
 #
 
 #..............................................................................

--- a/spectra/spec_io.py
+++ b/spectra/spec_io.py
@@ -34,7 +34,7 @@ def model_from_txt(fname, wave='vac', x_unit='AA', y_unit='erg/(s cm2 AA)', **kw
   """
   x, y = np.loadtxt(fname, unpack=True, usecols=(0,1), **kwargs)
   name = os.path.splitext(os.path.basename(fname))[0]
-  return Spectrum(x, y, np.zeros_like(x), name, wave, x_unit, y_unit)
+  return Spectrum(x, y, 0, name, wave, x_unit, y_unit)
 
 def model_from_dk(fname, x_unit='AA', y_unit='erg/(s cm2 AA)', **kwargs):
   """
@@ -55,14 +55,14 @@ def model_from_dk(fname, x_unit='AA', y_unit='erg/(s cm2 AA)', **kwargs):
 
 def spec_from_npy(fname, wave='air', x_unit='AA', y_unit='erg/(s cm2 AA)'):
   """
-  Loads a text file with the first 3 columns as wavelengths, fluxes, errors.
+  Loads a npy file with 2 or 3 columns as wavelengths, fluxes(, errors).
   """
   data = np.load(fname)
   assert data.ndim == 2, "Data must be 2D"
 
   if data.shape[0] == 2:
     x, y = data
-    e = np.zeros_like(x)
+    e = 0
   elif data.shape[0] == 3:
     x, y, e = data
   else:


### PR DESCRIPTION
Main change is that fluxes/errors needn't be arrays, but will be recast as arrays with the same shape as wavelengths. Makes the Zero/UnitSpectrum functions redundant, so they have been removed.